### PR TITLE
Add hack for MockProvider to workaround SDK issue

### DIFF
--- a/Microsoft.Toolkit.Graph/Providers/MockProvider.cs
+++ b/Microsoft.Toolkit.Graph/Providers/MockProvider.cs
@@ -45,6 +45,17 @@ namespace Microsoft.Toolkit.Graph.Providers
             "https://proxy.apisandbox.msdn.microsoft.com/svc?url=" + HttpUtility.HtmlEncode("https://graph.microsoft.com/beta/"),
             new DelegateAuthenticationProvider((requestMessage) =>
             {
+                //// Temporary Workaround for https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/59
+                //// ------------------------
+                var requestUri = requestMessage.RequestUri.ToString();
+                var index = requestUri.IndexOf("&");
+                if (index >= 0)
+                {
+                    requestMessage.RequestUri = new Uri(requestUri.Remove(index, 1).Insert(index, "?"));
+                }
+
+                //// End Workaround
+
                 return this.AuthenticateRequestAsync(requestMessage);
             }));
 


### PR DESCRIPTION
Resolves #24 for now

Works around issue with how Graph SDK resolves urls, detailed here: https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/59

For now, we know if we have a complex Query String that we should swap the first '&' with a '?' to make it a valid proxy service url.