### PR TITLE
Hide sign out flyout on click

### DIFF
--- a/Microsoft.Toolkit.Graph.Controls/Controls/LoginButton/LoginButton.cs
+++ b/Microsoft.Toolkit.Graph.Controls/Controls/LoginButton/LoginButton.cs
@@ -5,7 +5,6 @@
 using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
-using Microsoft.Graph.Auth;
 using Microsoft.Toolkit.Graph.Providers;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -181,6 +180,12 @@ namespace Microsoft.Toolkit.Graph.Controls
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task LogoutAsync()
         {
+            // Close Menu
+            if (FlyoutBase.GetAttachedFlyout(_loginButton) is FlyoutBase flyout)
+            {
+                flyout.Hide();
+            }
+
             var cargs = new CancelEventArgs();
             LogoutInitiated?.Invoke(this, cargs);
 
@@ -205,12 +210,6 @@ namespace Microsoft.Toolkit.Graph.Controls
                 await provider.LogoutAsync();
 
                 LogoutCompleted?.Invoke(this, new EventArgs());
-            }
-
-            // Close Menu
-            if (FlyoutBase.GetAttachedFlyout(_loginButton) is FlyoutBase flyout)
-            {
-                flyout.Hide();
             }
         }
     }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When clicking on the sign out hyperlink in the authenticated user flyout, the flyout remains visible without any information until the sign out is complete:

![image](https://user-images.githubusercontent.com/20152272/75727187-99bfbc80-5ce4-11ea-9abb-93bb26cd8574.png)

During this phase, the hyperlink remains clickable but is not doing anything.

## What is the new behavior?
The authenticated user flyout will now be dismissed immediately when clicking on the sign out hyperlink.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/windows-toolkit/Graph-Controls/blob/master/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
