### PR TITLE
Disable login button while login or logout

### DIFF
--- a/Microsoft.Toolkit.Graph.Controls/Controls/LoginButton/LoginButton.Properties.cs
+++ b/Microsoft.Toolkit.Graph.Controls/Controls/LoginButton/LoginButton.Properties.cs
@@ -46,6 +46,6 @@ namespace Microsoft.Toolkit.Graph.Controls
         /// The identifier for the <see cref="IsLoading"/> dependency property.
         /// </returns>
         public static readonly DependencyProperty IsLoadingProperty =
-            DependencyProperty.Register("IsLoading", typeof(bool), typeof(LoginButton), new PropertyMetadata(true));
+            DependencyProperty.Register(nameof(IsLoading), typeof(bool), typeof(LoginButton), new PropertyMetadata(true));
     }
 }

--- a/Microsoft.Toolkit.Graph.Controls/Controls/LoginButton/LoginButton.cs
+++ b/Microsoft.Toolkit.Graph.Controls/Controls/LoginButton/LoginButton.cs
@@ -4,8 +4,8 @@
 
 using System;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Threading.Tasks;
-using Microsoft.Graph.Auth;
 using Microsoft.Toolkit.Graph.Providers;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
@@ -33,15 +33,7 @@ namespace Microsoft.Toolkit.Graph.Controls
         {
             this.DefaultStyleKey = typeof(LoginButton);
 
-            ProviderManager.Instance.ProviderUpdated += (sender, args) =>
-            {
-                if (!IsLoading && ProviderManager.Instance?.GlobalProvider?.State == ProviderState.Loading)
-                {
-                    IsLoading = true;
-                }
-
-                LoadData();
-            };
+            ProviderManager.Instance.ProviderUpdated += (sender, args) => LoadData();
         }
 
         /// <inheritdoc/>
@@ -49,6 +41,7 @@ namespace Microsoft.Toolkit.Graph.Controls
         {
             base.OnApplyTemplate();
 
+            IsLoading = true;
             LoadData();
 
             if (_loginButton != null)
@@ -111,7 +104,11 @@ namespace Microsoft.Toolkit.Graph.Controls
                 return;
             }
 
-            if (provider.State == ProviderState.SignedIn)
+            if (provider.State == ProviderState.Loading)
+            {
+                IsLoading = true;
+            }
+            else if (provider.State == ProviderState.SignedIn)
             {
                 try
                 {
@@ -123,18 +120,20 @@ namespace Microsoft.Toolkit.Graph.Controls
                 {
                     LoginFailed?.Invoke(this, new LoginFailedEventArgs(e));
                 }
+
+                IsLoading = false;
             }
             else if (provider.State == ProviderState.SignedOut)
             {
                 UserDetails = null; // What if this was user provided? Should we not hook into these events then?
+
+                IsLoading = false;
             }
             else
             {
                 // Provider in Loading state
-                return;
+                Debug.Fail("unsupported state");
             }
-
-            IsLoading = false;
         }
 
         /// <summary>
@@ -143,7 +142,7 @@ namespace Microsoft.Toolkit.Graph.Controls
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task LoginAsync()
         {
-            if (UserDetails != null)
+            if (UserDetails != null || IsLoading)
             {
                 return;
             }
@@ -154,6 +153,7 @@ namespace Microsoft.Toolkit.Graph.Controls
             {
                 try
                 {
+                    IsLoading = true;
                     await provider.LoginAsync();
 
                     if (provider.State == ProviderState.SignedIn)
@@ -172,6 +172,10 @@ namespace Microsoft.Toolkit.Graph.Controls
                 {
                     LoginFailed?.Invoke(this, new LoginFailedEventArgs(e));
                 }
+                finally
+                {
+                    IsLoading = false;
+                }
             }
         }
 
@@ -181,6 +185,11 @@ namespace Microsoft.Toolkit.Graph.Controls
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public async Task LogoutAsync()
         {
+            if (IsLoading)
+            {
+                return;
+            }
+
             var cargs = new CancelEventArgs();
             LogoutInitiated?.Invoke(this, cargs);
 
@@ -202,7 +211,9 @@ namespace Microsoft.Toolkit.Graph.Controls
 
             if (provider != null)
             {
+                IsLoading = true;
                 await provider.LogoutAsync();
+                IsLoading = false;
 
                 LogoutCompleted?.Invoke(this, new EventArgs());
             }


### PR DESCRIPTION
Fixes #14

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The login button is not disabled during login/logout operations.

## What is the new behavior?
The login button will now be disabled during login/logout. I'm reusing the `IsLoading` property to enable/disable the button. It will be set to true before starting the operations.

The login/logout operations will be disabled while `IsLoading` is true.

## PR Checklist

- [x] Tested code with current [supported SDKs](https://github.com/windows-toolkit/Graph-Controls/blob/master/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
    - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run *build/UpdateHeaders.bat*)
- [x] Contains **NO** breaking changes