### PR TITLE
Added CurrentAccountId to IProvider

### DIFF
--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -41,6 +41,9 @@ namespace CommunityToolkit.Authentication
         // The default account providers available in the AccountsSettingsPane.
         private static readonly WebAccountProviderType DefaultWebAccountsProviderType = WebAccountProviderType.All;
 
+        /// <inheritdoc />
+        public override string CurrentAccountId => _webAccount?.Id;
+
         /// <summary>
         /// Gets the list of scopes to pre-authorize during authentication.
         /// </summary>

--- a/CommunityToolkit.Authentication/BaseProvider.cs
+++ b/CommunityToolkit.Authentication/BaseProvider.cs
@@ -34,6 +34,9 @@ namespace CommunityToolkit.Authentication
             }
         }
 
+        /// <inheritdoc />
+        public abstract string CurrentAccountId { get; }
+
         /// <inheritdoc/>
         public event EventHandler<ProviderStateChangedEventArgs> StateChanged;
 

--- a/CommunityToolkit.Authentication/IProvider.cs
+++ b/CommunityToolkit.Authentication/IProvider.cs
@@ -19,6 +19,11 @@ namespace CommunityToolkit.Authentication
         ProviderState State { get; }
 
         /// <summary>
+        /// Gets the id of the currently signed in user account.
+        /// </summary>
+        string CurrentAccountId { get; }
+
+        /// <summary>
         /// Event called when the login <see cref="State"/> changes.
         /// </summary>
         event EventHandler<ProviderStateChangedEventArgs> StateChanged;

--- a/CommunityToolkit.Authentication/MockProvider.cs
+++ b/CommunityToolkit.Authentication/MockProvider.cs
@@ -26,6 +26,9 @@ namespace CommunityToolkit.Authentication
             State = signedIn ? ProviderState.SignedIn : ProviderState.SignedOut;
         }
 
+        /// <inheritdoc />
+        public override string CurrentAccountId => State == ProviderState.SignedIn ? "mock-account-id" : null;
+
         /// <inheritdoc/>
         public override Task AuthenticateRequestAsync(HttpRequestMessage request)
         {


### PR DESCRIPTION
Fixes #

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the new behavior?

This PR introduces a new property on IProvider called `CurrentAccountId`, which reflects the identifier of the currently signed in user account. 

- For `MsalProvider` the id comes from `Microsoft.Identity.Client.AccountId.Identifier`
- For `WindowsProvider` the id comes from `Windows.Security.Credentials.WebAccount.Id`
- For `MockProvider` the id is a dummy value, "mock-account-id".

When NOT signed in `CurrentAccountId` returns `null`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/windows-toolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
