### PR TITLE
Support display account management panel

### DIFF
--- a/CommunityToolkit.Authentication.Uwp/AccountsSettingsPaneConfig.cs
+++ b/CommunityToolkit.Authentication.Uwp/AccountsSettingsPaneConfig.cs
@@ -13,9 +13,14 @@ namespace CommunityToolkit.Authentication
     public struct AccountsSettingsPaneConfig
     {
         /// <summary>
-        /// Gets or sets the header text for the accounts settings pane.
+        /// Gets or sets the header text for the add accounts settings pane.
         /// </summary>
-        public string HeaderText { get; set; }
+        public string AddAccountHeaderText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the header text for the manage accounts settings pane.
+        /// </summary>
+        public string ManageAccountHeaderText { get; set; }
 
         /// <summary>
         /// Gets or sets the SettingsCommand collection for the account settings pane.
@@ -23,14 +28,27 @@ namespace CommunityToolkit.Authentication
         public IList<SettingsCommand> Commands { get; set; }
 
         /// <summary>
+        /// Gets or sets the WebAccountCommandParameter collection for the account settings pane.
+        /// </summary>
+        public WebAccountCommandParameter AccountCommandParameter { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="AccountsSettingsPaneConfig"/> struct.
         /// </summary>
-        /// <param name="headerText">The header text for the accounts settings pane.</param>
+        /// <param name="addAccountHeaderText">The header text for the add accounts settings pane.</param>
+        /// <param name="manageAccountHeaderText">The header text for the manage accounts settings pane.</param>
         /// <param name="commands">The SettingsCommand collection for the account settings pane.</param>
-        public AccountsSettingsPaneConfig(string headerText = null, IList<SettingsCommand> commands = null)
+        /// <param name="accountCommandParameter">The WebAccountCommandParameter for the account settings pane.</param>
+        public AccountsSettingsPaneConfig(
+            string addAccountHeaderText = null,
+            string manageAccountHeaderText = null,
+            IList<SettingsCommand> commands = null,
+            WebAccountCommandParameter accountCommandParameter = null)
         {
-            HeaderText = headerText;
+            AddAccountHeaderText = addAccountHeaderText;
+            ManageAccountHeaderText = manageAccountHeaderText;
             Commands = commands;
+            AccountCommandParameter = accountCommandParameter;
         }
     }
 }

--- a/CommunityToolkit.Authentication.Uwp/WebAccountCommandParameter.cs
+++ b/CommunityToolkit.Authentication.Uwp/WebAccountCommandParameter.cs
@@ -1,0 +1,37 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Windows.UI.ApplicationSettings;
+
+namespace CommunityToolkit.Authentication
+{
+    /// <summary>
+    /// <see cref="WebAccountCommand"/> can be produced through this parameter.
+    /// </summary>
+    public class WebAccountCommandParameter
+    {
+        /// <summary>
+        /// Gets the delegate that's invoked when the user selects an account and a specific
+        /// action in the account settings pane.
+        /// </summary>
+        public WebAccountCommandInvokedHandler Invoked { get; }
+
+        /// <summary>
+        /// Gets the actions that the command performs on the web account in the accounts pane.
+        /// </summary>
+        public SupportedWebAccountActions Actions { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebAccountCommandParameter"/> class.
+        /// </summary>
+        /// <param name="invoked">The delegate that's invoked when the user selects an account and a specific
+        /// action in the account settings pane.</param>
+        /// <param name="actions">The actions that the command performs on the web account in the accounts pane.</param>
+        public WebAccountCommandParameter(WebAccountCommandInvokedHandler invoked, SupportedWebAccountActions actions)
+        {
+            Invoked = invoked;
+            Actions = actions;
+        }
+    }
+}

--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -270,6 +270,16 @@ namespace CommunityToolkit.Authentication
 
                 e.WebAccountCommands.Add(webAccountCommand);
 
+                // Apply any configured setting commands.
+                var commands = _accountsSettingsPaneConfig?.Commands;
+                if (commands != null)
+                {
+                    foreach (var command in commands)
+                    {
+                        e.Commands.Add(command);
+                    }
+                }
+
                 deferral.Complete();
             }
 

--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -224,13 +224,84 @@ namespace CommunityToolkit.Authentication
             return null;
         }
 
+        /// <summary>
+        /// Display AccountSettingsPane for the management of logged-in users.
+        /// </summary>
+        /// <returns><see cref="Task"/>.</returns>
+        public async Task ShowAccountManagementPaneAsync()
+        {
+            if (_webAccount == null)
+            {
+                throw new InvalidOperationException("Display account management pane requires at least one logged in account.");
+            }
+
+            if (_accountsSettingsPaneConfig?.AccountCommandParameter == null)
+            {
+                throw new ArgumentNullException("At least one account command is required to display the account management pane.");
+            }
+
+            // Build the AccountSettingsPane and configure it with available account commands.
+            void OnAccountCommandsRequested(AccountsSettingsPane sender, AccountsSettingsPaneCommandsRequestedEventArgs e)
+            {
+                AccountsSettingsPaneEventDeferral deferral = e.GetDeferral();
+
+                // Apply the configured header.
+                var headerText = _accountsSettingsPaneConfig?.ManageAccountHeaderText;
+                if (!string.IsNullOrWhiteSpace(headerText))
+                {
+                    e.HeaderText = headerText;
+                }
+
+                // Generate account command.
+                var commandParameter = _accountsSettingsPaneConfig?.AccountCommandParameter;
+                var webAccountCommand = new WebAccountCommand(
+                            _webAccount,
+                            async (command, args) =>
+                            {
+                                commandParameter.Invoked?.Invoke(command, args);
+
+                                // When the logout command is triggered, we also need to modify the state of the Provider.
+                                if (args.Action == WebAccountAction.Remove)
+                                {
+                                    await SignOutAsync();
+                                }
+                            },
+                            commandParameter.Actions);
+
+                e.WebAccountCommands.Add(webAccountCommand);
+
+                deferral.Complete();
+            }
+
+            AccountsSettingsPane pane = null;
+            try
+            {
+                // GetForCurrentView may throw an exception if the current view isn't ready yet.
+                pane = AccountsSettingsPane.GetForCurrentView();
+                pane.AccountCommandsRequested += OnAccountCommandsRequested;
+
+                // Show the AccountSettingsPane and wait for the result.
+                await AccountsSettingsPane.ShowManageAccountsAsync();
+            }
+            catch (Exception)
+            {
+            }
+            finally
+            {
+                if (pane != null)
+                {
+                    pane.AccountCommandsRequested -= OnAccountCommandsRequested;
+                }
+            }
+        }
+
         private async Task SetAccountAsync(WebAccount account)
         {
             if (account == null)
             {
                 // Clear account
-                 await SignOutAsync();
-                 return;
+                await SignOutAsync();
+                return;
             }
             else if (account.Id == _webAccount?.Id)
             {
@@ -353,7 +424,7 @@ namespace CommunityToolkit.Authentication
                     }
 
                     // Apply the configured header.
-                    var headerText = _accountsSettingsPaneConfig?.HeaderText;
+                    var headerText = _accountsSettingsPaneConfig?.AddAccountHeaderText;
                     if (!string.IsNullOrWhiteSpace(headerText))
                     {
                         e.HeaderText = headerText;

--- a/Samples/UwpWindowsProviderSample/AccountManagerButton.xaml
+++ b/Samples/UwpWindowsProviderSample/AccountManagerButton.xaml
@@ -1,0 +1,17 @@
+﻿<UserControl x:Class="UwpWindowsProviderSample.AccountManagerButton"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="using:UwpWindowsProviderSample"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             d:DesignHeight="300"
+             d:DesignWidth="400"
+             mc:Ignorable="d">
+
+    <Grid>
+        <Button x:Name="ManagerButton"
+                Click="ManagerButton_Click"
+                Content="Account management"
+                IsEnabled="{Binding IsEnabled}" />
+    </Grid>
+</UserControl>

--- a/Samples/UwpWindowsProviderSample/AccountManagerButton.xaml.cs
+++ b/Samples/UwpWindowsProviderSample/AccountManagerButton.xaml.cs
@@ -1,0 +1,36 @@
+﻿using CommunityToolkit.Authentication;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UwpWindowsProviderSample
+{
+    public sealed partial class AccountManagerButton : UserControl
+    {
+        public AccountManagerButton()
+        {
+            this.InitializeComponent();
+        }
+
+        private async void ManagerButton_Click(object sender, RoutedEventArgs e)
+        {
+            if(ProviderManager.Instance.GlobalProvider is WindowsProvider provider)
+            {
+                await provider.ShowAccountManagementPaneAsync();
+            }
+        }
+    }
+}

--- a/Samples/UwpWindowsProviderSample/AccountManagerButton.xaml.cs
+++ b/Samples/UwpWindowsProviderSample/AccountManagerButton.xaml.cs
@@ -1,23 +1,16 @@
-﻿using CommunityToolkit.Authentication;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using CommunityToolkit.Authentication;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace UwpWindowsProviderSample
 {
+    /// <summary>
+    /// A simple button for triggering the globally configured WindowsProvider to manage account.
+    /// </summary>
     public sealed partial class AccountManagerButton : UserControl
     {
         public AccountManagerButton()

--- a/Samples/UwpWindowsProviderSample/App.xaml.cs
+++ b/Samples/UwpWindowsProviderSample/App.xaml.cs
@@ -3,8 +3,12 @@
 // See the LICENSE file in the project root for more information.
 
 using CommunityToolkit.Authentication;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using Windows.ApplicationModel.Activation;
 using Windows.System;
+using Windows.UI.ApplicationSettings;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -32,10 +36,30 @@ namespace UwpWindowsProviderSample
                 if (ProviderManager.Instance.GlobalProvider == null)
                 {
                     string[] scopes = new string[] { "User.Read" };
-                    ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes);
+                    var paneConfig = GetAccountsSettingsPaneConfig();
+                    ProviderManager.Instance.GlobalProvider = new WindowsProvider(scopes, accountsSettingsPaneConfig: paneConfig);
                 }
             });
         }
+
+        AccountsSettingsPaneConfig GetAccountsSettingsPaneConfig()
+        {
+            void OnAccountCommandInvoked(WebAccountCommand command, WebAccountInvokedArgs args)
+            {
+                Debug.WriteLine($"Action: {args.Action}");
+            }
+
+            var accountCommandParameter = new WebAccountCommandParameter(
+                OnAccountCommandInvoked,
+                SupportedWebAccountActions.Remove | SupportedWebAccountActions.Manage);
+
+            var addAccountHeaderText = "Login account";
+            var manageAccountHeaderText = "Account management";
+
+            return new AccountsSettingsPaneConfig(addAccountHeaderText, manageAccountHeaderText, accountCommandParameter: accountCommandParameter);
+        }
+
+
 
         protected override void OnLaunched(LaunchActivatedEventArgs e)
         {

--- a/Samples/UwpWindowsProviderSample/MainPage.xaml
+++ b/Samples/UwpWindowsProviderSample/MainPage.xaml
@@ -1,15 +1,17 @@
-﻿<Page
-    x:Class="UwpWindowsProviderSample.MainPage"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:UwpWindowsProviderSample"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    mc:Ignorable="d"
-    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+﻿<Page x:Class="UwpWindowsProviderSample.MainPage"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:local="using:UwpWindowsProviderSample"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
+      mc:Ignorable="d">
 
     <StackPanel>
         <local:LoginButton />
+        <local:AccountManagerButton x:Name="ManagerButton"
+                                    Margin="0,8,0,0"
+                                    IsEnabled="False" />
         <TextBlock x:Name="SignedInUserTextBlock" />
     </StackPanel>
 </Page>

--- a/Samples/UwpWindowsProviderSample/MainPage.xaml.cs
+++ b/Samples/UwpWindowsProviderSample/MainPage.xaml.cs
@@ -23,9 +23,11 @@ namespace UwpWindowsProviderSample
             if (provider == null || provider.State != ProviderState.SignedIn)
             {
                 SignedInUserTextBlock.Text = "Please sign in.";
+                ManagerButton.IsEnabled = false;
             }
             else
             {
+                ManagerButton.IsEnabled = true;
                 SignedInUserTextBlock.Text = "Signed in as...";
 
                 var graphClient = provider.GetClient();

--- a/Samples/UwpWindowsProviderSample/UwpWindowsProviderSample.csproj
+++ b/Samples/UwpWindowsProviderSample/UwpWindowsProviderSample.csproj
@@ -116,6 +116,9 @@
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="AccountManagerButton.xaml.cs">
+      <DependentUpon>AccountManagerButton.xaml</DependentUpon>
+    </Compile>
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
@@ -147,6 +150,10 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Page Include="AccountManagerButton.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="LoginButton.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

**Feature**

Support display account management panel:

![image](https://user-images.githubusercontent.com/27713596/120764182-7ff5d080-c54a-11eb-9b80-dd3b4c9d17cc.png)

## What is the current behavior?

At this stage, `WindowsProvider` provides login and logout functions, the logout process does not require user involvement.

## What is the new behavior?

Some usage scenarios may need to display the currently logged-in user and provide some custom operations.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/windows-toolkit/Graph-Controls/blob/main/README.md)
- [x] Sample in sample app has been added / updated (for bug fixes / features)
  - [x] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

**Breaking changes**

The login panel and the management panel are two different usage scenarios, and their `HeaderText` may not be mixed, so I made some modifications:

1. Modify the original `HeaderText` to `AddAccountHeaderText`.
2. Add a new property `ManageAccountHeaderText` is used to display in the account management panel.
3. The constructor parameters of `AccountsSettingsPaneConfig` have been adjusted.

## Other information

A new object has been added: `WebAccountCommandParameter`. It is not used as an `IList` property in the definition of `AccountsSettingsPaneConfig`, because currently `WindowsProvider` only supports single account.