### PR TITLE
Added scopes parameter to IProvider.GetTokenAsync

### DIFF
--- a/CommunityToolkit.Authentication.Msal/MsalProvider.cs
+++ b/CommunityToolkit.Authentication.Msal/MsalProvider.cs
@@ -119,15 +119,17 @@ namespace CommunityToolkit.Authentication
         }
 
         /// <inheritdoc/>
-        public override async Task<string> GetTokenAsync(bool silentOnly = false)
+        public override async Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null)
         {
+            var tokenScopes = scopes ?? Scopes;
+
             AuthenticationResult authResult = null;
             try
             {
                 var account = _account ?? (await Client.GetAccountsAsync()).FirstOrDefault();
                 if (account != null)
                 {
-                    authResult = await Client.AcquireTokenSilent(Scopes, account).ExecuteAsync();
+                    authResult = await Client.AcquireTokenSilent(tokenScopes, account).ExecuteAsync();
                 }
             }
             catch (MsalUiRequiredException)
@@ -143,7 +145,7 @@ namespace CommunityToolkit.Authentication
             {
                 try
                 {
-                    authResult = await Client.AcquireTokenInteractive(Scopes).WithPrompt(Prompt.SelectAccount).ExecuteAsync();
+                    authResult = await Client.AcquireTokenInteractive(tokenScopes).WithPrompt(Prompt.SelectAccount).ExecuteAsync();
                 }
                 catch
                 {

--- a/CommunityToolkit.Authentication/BaseProvider.cs
+++ b/CommunityToolkit.Authentication/BaseProvider.cs
@@ -51,8 +51,8 @@ namespace CommunityToolkit.Authentication
         /// <inheritdoc />
         public abstract Task AuthenticateRequestAsync(HttpRequestMessage request);
 
-        /// <inheritdoc/>
-        public abstract Task<string> GetTokenAsync(bool silentOnly = false);
+        /// <inheritdoc />
+        public abstract Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null);
 
         /// <inheritdoc />
         public abstract Task SignInAsync();

--- a/CommunityToolkit.Authentication/IProvider.cs
+++ b/CommunityToolkit.Authentication/IProvider.cs
@@ -39,8 +39,9 @@ namespace CommunityToolkit.Authentication
         /// Retrieve a token for the authenticated user.
         /// </summary>
         /// <param name="silentOnly">Determines if the acquisition should be done without prompts to the user.</param>
+        /// <param name="scopes">Additional scopes to request access for.</param>
         /// <returns>A token string for the authenticated user.</returns>
-        Task<string> GetTokenAsync(bool silentOnly = false);
+        Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null);
 
         /// <summary>
         /// Sign in the user.

--- a/CommunityToolkit.Authentication/MockProvider.cs
+++ b/CommunityToolkit.Authentication/MockProvider.cs
@@ -46,7 +46,7 @@ namespace CommunityToolkit.Authentication
         }
 
         /// <inheritdoc/>
-        public override Task<string> GetTokenAsync(bool silentOnly = false)
+        public override Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null)
         {
             return Task.FromResult("<mock-provider-token>");
         }


### PR DESCRIPTION
Fixes #111

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature 
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Currently, there is no way to request an access token for scopes that were not initially requested during provider construction.
 This limits the ability to adopt Graph APIs over time, as features are introduced.

```
// In app startup code:
// The provider is constructed with an initial set of scopes.
string[] initialScopes = new string[] { "User.Read" };
ProviderManager.Instance.GlobalProvider = new WindowsProvider(initialScopes);

// Somewhere else in the app:
// GetTokenAsync can only retrieve a token configured for the scopes created during provider construction.
IProvider provider = ProviderManager.Instance.GlobalProvider;
string token = await provider.GetTokenAsync(silentOnly: false);
```

## What is the new behavior?

The new behavior adds an additional `string[] scopes = null` parameter to the end of `GetTokenAsync`. This allows the option of providing a specific set of scopes to request in the access token:

```
// App startup code, same as before.

// Somewhere else in the app:
// Alternate scopes can now be requested ad hoc.
IProvider provider = ProviderManager.Instance.GlobalProvider;
string[] alternateScopes = new string[] { "Tasks.ReadWrite", "People.Read" };
string token = await provider.GetTokenAsync(false, alternateScopes);
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/windows-toolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information