### PR TITLE
Updated LoginButton events to respond to GlobalProvider

### DIFF
--- a/CommunityToolkit.Graph.Uwp/Controls/LoginButton/LoginButton.Properties.cs
+++ b/CommunityToolkit.Graph.Uwp/Controls/LoginButton/LoginButton.Properties.cs
@@ -18,7 +18,7 @@ namespace CommunityToolkit.Graph.Uwp.Controls
         public User UserDetails
         {
             get { return (User)GetValue(UserDetailsProperty); }
-            set { SetValue(UserDetailsProperty, value); }
+            protected set { SetValue(UserDetailsProperty, value); }
         }
 
         /// <summary>

--- a/CommunityToolkit.Graph.Uwp/Controls/LoginButton/LoginButton.cs
+++ b/CommunityToolkit.Graph.Uwp/Controls/LoginButton/LoginButton.cs
@@ -17,14 +17,14 @@ namespace CommunityToolkit.Graph.Uwp.Controls
     /// The <see cref="LoginButton"/> control is a button which can be used to sign the user in or show them profile details.
     /// </summary>
     [TemplatePart(Name = LoginButtonPart, Type = typeof(Button))]
-    [TemplatePart(Name = SignOutButtonPart, Type = typeof(ButtonBase))]
+    [TemplatePart(Name = LogoutButtonPart, Type = typeof(ButtonBase))]
     public partial class LoginButton : Control
     {
         private const string LoginButtonPart = "PART_LoginButton";
-        private const string SignOutButtonPart = "PART_SignOutButton";
+        private const string LogoutButtonPart = "PART_LogoutButton";
 
         private Button _loginButton;
-        private ButtonBase _signOutButton;
+        private ButtonBase _logoutButton;
 
         private bool _isLoading;
 
@@ -48,18 +48,88 @@ namespace CommunityToolkit.Graph.Uwp.Controls
         {
             this.DefaultStyleKey = typeof(LoginButton);
 
-            ProviderManager.Instance.ProviderUpdated += (sender, args) => LoadData();
-            ProviderManager.Instance.ProviderStateChanged += (sender, args) => LoadData();
+            ProviderManager.Instance.ProviderUpdated += OnProviderUpdated;
+            ProviderManager.Instance.ProviderStateChanged += OnProviderStateChanged;
         }
 
         /// <summary>
-        /// Update the enablement state of the button in relation to the _isLoading property.
+        /// Initiates logging in with the current <see cref="IProvider"/> registered in the <see cref="ProviderManager"/>.
         /// </summary>
-        protected void UpdateButtonEnablement()
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task SignInAsync()
         {
-            if (_loginButton != null)
+            if (IsLoading)
             {
-                _loginButton.IsEnabled = !_isLoading;
+                return;
+            }
+
+            var provider = ProviderManager.Instance.GlobalProvider;
+            if (provider != null)
+            {
+                try
+                {
+                    IsLoading = true;
+
+                    var cargs = new CancelEventArgs();
+                    LoginInitiated?.Invoke(this, cargs);
+                    if (cargs.Cancel)
+                    {
+                        IsLoading = false;
+                        throw new OperationCanceledException();
+                    }
+
+                    await provider.SignInAsync();
+
+                    if (provider.State != ProviderState.SignedIn)
+                    {
+                        throw new Exception("Login did not complete.");
+                    }
+                }
+                catch (Exception e)
+                {
+                    IsLoading = false;
+                    LoginFailed?.Invoke(this, new LoginFailedEventArgs(e));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Log a signed-in user out.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public async Task SignOutAsync()
+        {
+            if (IsLoading)
+            {
+                return;
+            }
+
+            IsLoading = true;
+
+            var cargs = new CancelEventArgs();
+            LogoutInitiated?.Invoke(this, cargs);
+            if (cargs.Cancel)
+            {
+                return;
+            }
+
+            var provider = ProviderManager.Instance.GlobalProvider;
+            if (provider != null)
+            {
+                try
+                {
+                    await provider.SignOutAsync();
+
+                    if (provider.State != ProviderState.SignedOut)
+                    {
+                        throw new Exception("Logout did not complete.");
+                    }
+                }
+                catch
+                {
+                    // There is no LogoutFailed event, so we do nothing.
+                    IsLoading = false;
+                }
             }
         }
 
@@ -80,49 +150,114 @@ namespace CommunityToolkit.Graph.Uwp.Controls
                 _loginButton.Click += LoginButton_Click;
             }
 
-            if (_signOutButton != null)
+            if (_logoutButton != null)
             {
-                _signOutButton.Click -= LoginButton_Click;
+                _logoutButton.Click -= LogoutButton_Click;
             }
 
-            _signOutButton = GetTemplateChild(SignOutButtonPart) as ButtonBase;
+            _logoutButton = GetTemplateChild(LogoutButtonPart) as ButtonBase;
 
-            if (_signOutButton != null)
+            if (_logoutButton != null)
             {
-                _signOutButton.Click += SignOutButton_Click;
+                _logoutButton.Click += LogoutButton_Click;
             }
 
             LoadData();
         }
 
-        private async void LoginButton_Click(object sender, RoutedEventArgs e)
+        /// <summary>
+        /// Show the user details flyout.
+        /// </summary>
+        protected void ShowFlyout()
         {
-            if (this.UserDetails != null)
+            if (FlyoutBase.GetAttachedFlyout(_loginButton) is FlyoutBase flyout)
             {
-                if (FlyoutBase.GetAttachedFlyout(_loginButton) is FlyoutBase flyout)
-                {
-                    flyout.ShowAt(_loginButton);
-                }
-            }
-            else
-            {
-                var cargs = new CancelEventArgs();
-                LoginInitiated?.Invoke(this, cargs);
-
-                if (!cargs.Cancel)
-                {
-                    await SignInAsync();
-                }
+                flyout.ShowAt(_loginButton);
             }
         }
 
-        private async void SignOutButton_Click(object sender, RoutedEventArgs e)
+        /// <summary>
+        /// Hide the user details flyout.
+        /// </summary>
+        protected void HideFlyout()
         {
+            if (FlyoutBase.GetAttachedFlyout(_loginButton) is FlyoutBase flyout)
+            {
+                flyout.Hide();
+            }
+        }
+
+        /// <summary>
+        /// Update the enablement state of the button in relation to the _isLoading property.
+        /// </summary>
+        protected void UpdateButtonEnablement()
+        {
+            if (_loginButton != null)
+            {
+                _loginButton.IsEnabled = !_isLoading;
+            }
+        }
+
+        private void OnProviderUpdated(object sender, IProvider e)
+        {
+            if (e == null)
+            {
+                ClearUserDetails();
+            }
+        }
+
+        private async void OnProviderStateChanged(object sender, ProviderStateChangedEventArgs e)
+        {
+            var provider = ProviderManager.Instance.GlobalProvider;
+            switch (provider.State)
+            {
+                case ProviderState.SignedIn:
+                    IsLoading = true;
+                    await SetUserDetails();
+                    IsLoading = false;
+                    LoginCompleted?.Invoke(this, new EventArgs());
+                    break;
+
+                case ProviderState.SignedOut:
+                    ClearUserDetails();
+                    IsLoading = false;
+                    LogoutCompleted?.Invoke(this, new EventArgs());
+                    break;
+
+                case ProviderState.Loading:
+                    IsLoading = true;
+                    break;
+            }
+        }
+
+        private async void LoginButton_Click(object sender, RoutedEventArgs e)
+        {
+            var provider = ProviderManager.Instance.GlobalProvider;
+            switch (provider.State)
+            {
+                case ProviderState.SignedIn:
+                    ShowFlyout();
+                    break;
+
+                case ProviderState.SignedOut:
+                    await SignInAsync();
+                    break;
+            }
+        }
+
+        private async void LogoutButton_Click(object sender, RoutedEventArgs e)
+        {
+            HideFlyout();
             await SignOutAsync();
         }
 
         private async void LoadData()
         {
+            if (IsLoading)
+            {
+                return;
+            }
+
             var provider = ProviderManager.Instance.GlobalProvider;
             switch (provider?.State)
             {
@@ -131,110 +266,39 @@ namespace CommunityToolkit.Graph.Uwp.Controls
                     break;
 
                 case ProviderState.SignedIn:
-                    try
+                    if (UserDetails == null)
                     {
-                        IsLoading = true;
+                        await SignInAsync();
+                    }
 
-                        // https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/src/components/mgt-login/mgt-login.ts#L139
-                        // TODO: Batch with photo request later? https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/29
-                        UserDetails = await provider.GetClient().GetMeAsync();
-                    }
-                    catch (Exception e)
-                    {
-                        LoginFailed?.Invoke(this, new LoginFailedEventArgs(e));
-                    }
-                    
                     IsLoading = false;
                     break;
 
                 case ProviderState.SignedOut:
-                default:
-                    UserDetails = null; // What if this was user provided? Should we not hook into these events then?
+                    if (UserDetails != null)
+                    {
+                        await SignOutAsync();
+                    }
+
                     IsLoading = false;
                     break;
             }
         }
 
-        /// <summary>
-        /// Initiates logging in with the current <see cref="IProvider"/> registered in the <see cref="ProviderManager"/>.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task SignInAsync()
+        private async Task SetUserDetails()
         {
-            if (UserDetails != null || IsLoading)
-            {
-                return;
-            }
-
             var provider = ProviderManager.Instance.GlobalProvider;
-
             if (provider != null)
             {
-                try
-                {
-                    IsLoading = true;
-                    await provider.SignInAsync();
-
-                    if (provider.State != ProviderState.SignedIn)
-                    {
-                        throw new TimeoutException("Login did not complete.");
-                    }
-
-                    LoadData();
-                }
-                catch (Exception e)
-                {
-                    LoginFailed?.Invoke(this, new LoginFailedEventArgs(e));
-                }
-                finally
-                {
-                    IsLoading = false;
-                }
+                // https://github.com/microsoftgraph/microsoft-graph-toolkit/blob/master/src/components/mgt-login/mgt-login.ts#L139
+                // TODO: Batch with photo request later? https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/29
+                UserDetails = await provider.GetClient().GetMeAsync();
             }
         }
 
-        /// <summary>
-        /// Log a signed-in user out.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async Task SignOutAsync()
+        private void ClearUserDetails()
         {
-            // Close Menu
-            if (FlyoutBase.GetAttachedFlyout(_loginButton) is FlyoutBase flyout)
-            {
-                flyout.Hide();
-            }
-
-            if (IsLoading)
-            {
-                return;
-            }
-
-            var cargs = new CancelEventArgs();
-            LogoutInitiated?.Invoke(this, cargs);
-
-            if (cargs.Cancel)
-            {
-                return;
-            }
-
-            if (UserDetails != null)
-            {
-                UserDetails = null;
-            }
-            else
-            {
-                return; // No-op
-            }
-
-            var provider = ProviderManager.Instance.GlobalProvider;
-
-            if (provider != null)
-            {
-                IsLoading = true;
-                await provider.SignOutAsync();
-                IsLoading = false;
-            }
+            UserDetails = null;
         }
     }
 }

--- a/CommunityToolkit.Graph.Uwp/Controls/LoginButton/LoginButton.cs
+++ b/CommunityToolkit.Graph.Uwp/Controls/LoginButton/LoginButton.cs
@@ -74,7 +74,6 @@ namespace CommunityToolkit.Graph.Uwp.Controls
                     LoginInitiated?.Invoke(this, cargs);
                     if (cargs.Cancel)
                     {
-                        IsLoading = false;
                         throw new OperationCanceledException();
                     }
 
@@ -125,7 +124,7 @@ namespace CommunityToolkit.Graph.Uwp.Controls
                         throw new Exception("Logout did not complete.");
                     }
                 }
-                catch
+                finally
                 {
                     // There is no LogoutFailed event, so we do nothing.
                     IsLoading = false;

--- a/CommunityToolkit.Graph.Uwp/Controls/LoginButton/LoginButton.xaml
+++ b/CommunityToolkit.Graph.Uwp/Controls/LoginButton/LoginButton.xaml
@@ -45,7 +45,7 @@
                                 <StackPanel>
                                     <local:PersonView PersonDetails="{Binding UserDetails, Converter={StaticResource UserToPersonConverter}, RelativeSource={RelativeSource TemplatedParent}}"
                                                       PersonViewType="TwoLines" />
-                                    <HyperlinkButton x:Name="PART_SignOutButton">
+                                    <HyperlinkButton x:Name="PART_LogoutButton">
                                         <TextBlock Text="Sign Out" />
                                     </HyperlinkButton>
                                 </StackPanel>


### PR DESCRIPTION
Fixes #101

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Currently, the Login/Logout-Completed events on LoginButton only fire when actually interacting with the button. This can make it difficult to use the LoginButton events reliably, since they won't fire if the GlobalProvider is updated directly.

## What is the new behavior?

The new behavior allows the LoginButton to emit Login/Logout-Completed events in response to state changes in the GlobalProvider. When the GlobalProvider state changes, the LoginButton will emit those events as appropriate. 

Note: The Login/Logout-Initiated events will not fire. This is because we have limited ability to understand the login flow based on the ProviderState enum values, SignedIn, SignedOut, and Loading.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/windows-toolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
