### PR TITLE
Added GlobalProviderState to ProviderManager property for easy binding

### DIFF
--- a/CommunityToolkit.Authentication/ProviderManager.cs
+++ b/CommunityToolkit.Authentication/ProviderManager.cs
@@ -15,7 +15,7 @@ namespace CommunityToolkit.Authentication
     /// ProviderManager.Instance.GlobalProvider = await MsalProvider.CreateAsync(...);
     /// </code>
     /// </example>
-    public partial class ProviderManager
+    public partial class ProviderManager : INotifyPropertyChanged
     {
         /// <summary>
         /// Gets the name of the toolkit client to identify self in Graph calls.
@@ -37,7 +37,8 @@ namespace CommunityToolkit.Authentication
         /// </summary>
         public event EventHandler<ProviderStateChangedEventArgs> ProviderStateChanged;
 
-        private IProvider _provider;
+        /// <inheritdoc />
+        public event PropertyChangedEventHandler PropertyChanged;
 
         /// <summary>
         /// Gets or sets the global provider used by all Microsoft.Toolkit.Graph.Controls.
@@ -54,7 +55,7 @@ namespace CommunityToolkit.Authentication
                 var oldState = _provider?.State;
                 if (_provider != null)
                 {
-                    _provider.StateChanged -= ProviderStateChanged;
+                    _provider.StateChanged -= OnProviderStateChanged;
                 }
 
                 _provider = value;
@@ -62,17 +63,33 @@ namespace CommunityToolkit.Authentication
                 var newState = _provider?.State;
                 if (_provider != null)
                 {
-                    _provider.StateChanged += ProviderStateChanged;
+                    _provider.StateChanged += OnProviderStateChanged;
                 }
 
                 ProviderUpdated?.Invoke(this, _provider);
                 ProviderStateChanged?.Invoke(this, new ProviderStateChangedEventArgs(oldState, newState));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GlobalProvider)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GlobalProviderState)));
             }
         }
+
+        /// <summary>
+        /// Gets the ProviderState of the current GlobalProvider instance.
+        /// Use for binding scenarios instead of ProviderManager.Instance.GlobalProvider.State.
+        /// </summary>
+        public ProviderState? GlobalProviderState => GlobalProvider?.State;
+
+        private IProvider _provider;
 
         private ProviderManager()
         {
             // Use Instance
+        }
+
+        private void OnProviderStateChanged(object sender, ProviderStateChangedEventArgs args)
+        {
+            ProviderStateChanged?.Invoke(sender, args);
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GlobalProviderState)));
         }
     }
 }

--- a/CommunityToolkit.Authentication/ProviderManager.cs
+++ b/CommunityToolkit.Authentication/ProviderManager.cs
@@ -8,11 +8,11 @@ using System.ComponentModel;
 namespace CommunityToolkit.Authentication
 {
     /// <summary>
-    /// Shared provider manager used by controls in Microsoft.Toolkit.Graph.Controls to authenticate and call the Microsoft Graph.
+    /// Shared provider manager used by controls and helpers to authenticate and call the Microsoft Graph.
     /// </summary>
     /// <example>To set your own existing provider:
     /// <code>
-    /// ProviderManager.Instance.GlobalProvider = await MsalProvider.CreateAsync(...);
+    /// ProviderManager.Instance.GlobalProvider = await new MsalProvider(clientId, scopes);
     /// </code>
     /// </example>
     public partial class ProviderManager : INotifyPropertyChanged
@@ -69,7 +69,7 @@ namespace CommunityToolkit.Authentication
                 ProviderUpdated?.Invoke(this, _provider);
                 ProviderStateChanged?.Invoke(this, new ProviderStateChangedEventArgs(oldState, newState));
                 PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GlobalProvider)));
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GlobalProviderState)));
+                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(State)));
             }
         }
 
@@ -77,7 +77,7 @@ namespace CommunityToolkit.Authentication
         /// Gets the ProviderState of the current GlobalProvider instance.
         /// Use for binding scenarios instead of ProviderManager.Instance.GlobalProvider.State.
         /// </summary>
-        public ProviderState? GlobalProviderState => GlobalProvider?.State;
+        public ProviderState? State => GlobalProvider?.State;
 
         private IProvider _provider;
 
@@ -89,7 +89,7 @@ namespace CommunityToolkit.Authentication
         private void OnProviderStateChanged(object sender, ProviderStateChangedEventArgs args)
         {
             ProviderStateChanged?.Invoke(sender, args);
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(GlobalProviderState)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(State)));
         }
     }
 }


### PR DESCRIPTION
Fixes #

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
SwitchPresenter from WCT doesn't work well with the GlobalProvider state as it exists today. It is not possible to simply use `ProviderManager.Instance.GlobalProvider.State` because the `GlobalProvider.State` is only available after the provider has been set, so the initial binding fails and updates are never processed.

## What is the new behavior?

Use the new `GlobalProviderState` getter to retrieve the current state of the active GlobalProvider, or `null` if none.

This is helpful for binding in XAML, since `GlobalProviderState` is consistently available via the ProviderManager.Instance singleton.

```
<controls:SwitchPresenter Value="{x:Bind auth:ProviderManager.Instance.GlobalProviderState, Mode=OneWay}">

    <controls:Case Value="{x:Bind auth:ProviderState.SignedIn}">
        <TextBlock Text="Signed in!" />
    </controls:Case>

    <controls:Case Value="{x:Bind auth:ProviderState.SignedOut}">
        <TextBlock Text="Signed out" />
    </controls:Case>

    <controls:Case Value="{x:Bind auth:ProviderState.Loading}">
        <TextBlock Text="Loading..." />
    </controls:Case>

    <controls:Case IsDefault="True">
        <TextBlock Text="No provider is set" />
    </controls:Case>
</controls:SwitchPresenter>
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/windows-toolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
