### PR TITLE
Removed scopes param from IProvider.GetTokenAsync

### DIFF
--- a/CommunityToolkit.Authentication.Msal/MsalProvider.cs
+++ b/CommunityToolkit.Authentication.Msal/MsalProvider.cs
@@ -119,17 +119,15 @@ namespace CommunityToolkit.Authentication
         }
 
         /// <inheritdoc/>
-        public override async Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null)
+        public override async Task<string> GetTokenAsync(bool silentOnly = false)
         {
-            var tokenScopes = scopes ?? Scopes;
-
             AuthenticationResult authResult = null;
             try
             {
                 var account = _account ?? (await Client.GetAccountsAsync()).FirstOrDefault();
                 if (account != null)
                 {
-                    authResult = await Client.AcquireTokenSilent(tokenScopes, account).ExecuteAsync();
+                    authResult = await Client.AcquireTokenSilent(Scopes, account).ExecuteAsync();
                 }
             }
             catch (MsalUiRequiredException)
@@ -145,7 +143,7 @@ namespace CommunityToolkit.Authentication
             {
                 try
                 {
-                    authResult = await Client.AcquireTokenInteractive(tokenScopes).WithPrompt(Prompt.SelectAccount).ExecuteAsync();
+                    authResult = await Client.AcquireTokenInteractive(Scopes).WithPrompt(Prompt.SelectAccount).ExecuteAsync();
                 }
                 catch
                 {

--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -172,7 +172,7 @@ namespace CommunityToolkit.Authentication
         }
 
         /// <inheritdoc />
-        public override async Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null)
+        public override async Task<string> GetTokenAsync(bool silentOnly = false)
         {
             var internetConnectionProfile = NetworkInformation.GetInternetConnectionProfile();
             if (internetConnectionProfile == null)
@@ -184,10 +184,8 @@ namespace CommunityToolkit.Authentication
 
             try
             {
-                var tokenScopes = scopes ?? _scopes;
-
                 // Attempt to authenticate silently.
-                var authResult = await AuthenticateSilentAsync(tokenScopes);
+                var authResult = await AuthenticateSilentAsync(_scopes);
 
                 // Authenticate with user interaction as appropriate.
                 if (authResult?.ResponseStatus != WebTokenRequestStatus.Success)
@@ -199,7 +197,7 @@ namespace CommunityToolkit.Authentication
                     }
 
                     // Attempt to authenticate interactively.
-                    authResult = await AuthenticateInteractiveAsync(tokenScopes);
+                    authResult = await AuthenticateInteractiveAsync(_scopes);
                 }
 
                 if (authResult?.ResponseStatus == WebTokenRequestStatus.Success)

--- a/CommunityToolkit.Authentication/BaseProvider.cs
+++ b/CommunityToolkit.Authentication/BaseProvider.cs
@@ -52,7 +52,7 @@ namespace CommunityToolkit.Authentication
         public abstract Task AuthenticateRequestAsync(HttpRequestMessage request);
 
         /// <inheritdoc />
-        public abstract Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null);
+        public abstract Task<string> GetTokenAsync(bool silentOnly = false);
 
         /// <inheritdoc />
         public abstract Task SignInAsync();

--- a/CommunityToolkit.Authentication/IProvider.cs
+++ b/CommunityToolkit.Authentication/IProvider.cs
@@ -39,9 +39,8 @@ namespace CommunityToolkit.Authentication
         /// Retrieve a token for the authenticated user.
         /// </summary>
         /// <param name="silentOnly">Determines if the acquisition should be done without prompts to the user.</param>
-        /// <param name="scopes">Additional scopes to request access for.</param>
         /// <returns>A token string for the authenticated user.</returns>
-        Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null);
+        Task<string> GetTokenAsync(bool silentOnly = false);
 
         /// <summary>
         /// Sign in the user.

--- a/CommunityToolkit.Authentication/MockProvider.cs
+++ b/CommunityToolkit.Authentication/MockProvider.cs
@@ -46,7 +46,7 @@ namespace CommunityToolkit.Authentication
         }
 
         /// <inheritdoc/>
-        public override Task<string> GetTokenAsync(bool silentOnly = false, string[] scopes = null)
+        public override Task<string> GetTokenAsync(bool silentOnly = false)
         {
             return Task.FromResult("<mock-provider-token>");
         }


### PR DESCRIPTION
Fixes #

<!-- Link to relevant issue (for ex: #1234) which will automatically close the issue once the PR is merged -->

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
WAM doesn't support incremental consent, so this function is deceiving. Only pre-authorized scopes will return a token successfully, in which case they should be included with the rest of the scopes provided during provider construction.

## What is the new behavior?

I've removed the *scopes* param from IProvider.GetTokenAsync.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/windows-toolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/windows-toolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
