### PR TITLE
Fix AAD silent login problem

### DIFF
--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -31,6 +31,7 @@ namespace CommunityToolkit.Authentication
         private const string MicrosoftProviderId = "https://login.microsoft.com";
         private const string SettingsKeyAccountId = "WindowsProvider_AccountId";
         private const string SettingsKeyProviderId = "WindowsProvider_ProviderId";
+        private const string SettingsKeyProviderAuthority = "WindowsProvider_Authority";
 
         private static readonly SemaphoreSlim SemaphoreSlim = new (1);
 
@@ -355,6 +356,7 @@ namespace CommunityToolkit.Authentication
             _webAccount = account;
             Settings[SettingsKeyAccountId] = account.Id;
             Settings[SettingsKeyProviderId] = account.WebAccountProvider.Id;
+            Settings[SettingsKeyProviderAuthority] = account.WebAccountProvider.Authority;
 
             State = ProviderState.SignedIn;
         }
@@ -370,9 +372,10 @@ namespace CommunityToolkit.Authentication
                 {
                     // Check the cache for an existing user
                     if (Settings[SettingsKeyAccountId] is string savedAccountId &&
-                        Settings[SettingsKeyProviderId] is string savedProviderId)
+                        Settings[SettingsKeyProviderId] is string savedProviderId &&
+                        Settings[SettingsKeyProviderAuthority] is string savedProviderAuthority)
                     {
-                        var savedProvider = await WebAuthenticationCoreManager.FindAccountProviderAsync(savedProviderId);
+                        var savedProvider = await WebAuthenticationCoreManager.FindAccountProviderAsync(savedProviderId, savedProviderAuthority);
                         account = await WebAuthenticationCoreManager.FindAccountAsync(savedProvider, savedAccountId);
                     }
                 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

After logging in to the AAD account, close and reopen the application, the login panel will still pop up instead of silent login.

## What is the new behavior?

Store the `Authority` property of the AAD account correctly, so that account data can be obtained when reading the locally cache.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](https://github.com/CommunityToolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information

MSA and AAD accounts require different authorization methods. The snippets from [this document](https://docs.microsoft.com/en-us/windows/uwp/security/web-account-manager#build-the-account-settings-pane) are as follows:

> Notice that we also pass the string "consumers" to the optional authority parameter. This is because Microsoft provides two different types of authentication - Microsoft Accounts (MSA) for "consumers", and Azure Active Directory (AAD) for "organizations". The "consumers" authority indicates we want the MSA option. If you're developing an enterprise app, use the string "organizations" instead.