### PR TITLE
Revert "Bump version to 7.1.2"

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.1.2-build.{height}",
+  "version": "7.1.1-build.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of main
     "^refs/heads/dev$", // we release out of dev


### PR DESCRIPTION
Reverts CommunityToolkit/Graph-Controls#174

There was a bit of a hiccup in the build in the 7.1.1 release yesterday, so we decided to re-release. But now we don't really need a 7.1.2 after all, because we can lump the latest hotfix in with the re-release. 👍 Fortunate accidents