### PR TITLE
Support for injecting WebTokenRequest.Properties

### DIFF
--- a/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
+++ b/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
@@ -20,14 +20,26 @@ namespace CommunityToolkit.Authentication
         public WebAccountProviderType WebAccountProviderType { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether to use Version 2 model, the default value is <c>False</c>.
+        /// </summary>
+        /// <remarks>
+        /// This option is configured for pre-authorization applications.
+        /// If the application is configured with pre-authorization,
+        /// this option can be set to <c>True</c> to skip consent page.
+        /// </remarks>
+        public bool UseApiVersion2 { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="WebAccountProviderConfig"/> struct.
         /// </summary>
         /// <param name="webAccountProviderType">The types of accounts providers that should be available to the user.</param>
         /// <param name="clientId">The registered ClientId. Required for AAD login and admin consent.</param>
-        public WebAccountProviderConfig(WebAccountProviderType webAccountProviderType, string clientId = null)
+        /// <param name="useApiVersion2">Whether to enable the version 2 model for the application.</param>
+        public WebAccountProviderConfig(WebAccountProviderType webAccountProviderType, string clientId = null, bool useApiVersion2 = false)
         {
             WebAccountProviderType = webAccountProviderType;
             ClientId = clientId;
+            UseApiVersion2 = useApiVersion2;
         }
     }
 }

--- a/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
+++ b/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
@@ -22,12 +22,12 @@ namespace CommunityToolkit.Authentication
         public WebAccountProviderType WebAccountProviderType { get; set; }
 
         /// <summary>
-        /// Gets or sets the properties that need to be added when constructing WebTokenRequest (for MSA).
+        /// Gets or sets the properties that need to be added when constructing <see cref="Windows.Security.Authentication.Web.Core.WebTokenRequest"/> (for MSA).
         /// </summary>
         public IDictionary<string, string> MSATokenRequestProperties { get; set; }
 
         /// <summary>
-        /// Gets or sets the properties that need to be added when constructing WebTokenRequest (for AAD).
+        /// Gets or sets the properties that need to be added when constructing <see cref="Windows.Security.Authentication.Web.Core.WebTokenRequest"/> (for AAD).
         /// </summary>
         public IDictionary<string, string> AADTokenRequestProperties { get; set; }
 

--- a/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
+++ b/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using System.Collections.Generic;
+
 namespace CommunityToolkit.Authentication
 {
     /// <summary>
@@ -20,26 +22,32 @@ namespace CommunityToolkit.Authentication
         public WebAccountProviderType WebAccountProviderType { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to use Version 2 model, only for MSA, the default value is <c>False</c>.
+        /// Gets or sets the properties that need to be added when constructing WebTokenRequest (for MSA).
         /// </summary>
-        /// <remarks>
-        /// This option is configured for pre-authorization applications.
-        /// If the application is configured with MSA pre-authorization,
-        /// this option can be set to <c>True</c> to skip consent page.
-        /// </remarks>
-        public bool UseApiVersion2 { get; set; }
+        public IDictionary<string, string> MSATokenRequestProperties { get; set; }
+
+        /// <summary>
+        /// Gets or sets the properties that need to be added when constructing WebTokenRequest (for AAD).
+        /// </summary>
+        public IDictionary<string, string> AADTokenRequestProperties { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="WebAccountProviderConfig"/> struct.
         /// </summary>
         /// <param name="webAccountProviderType">The types of accounts providers that should be available to the user.</param>
         /// <param name="clientId">The registered ClientId. Required for AAD login and admin consent.</param>
-        /// <param name="useApiVersion2">Whether to enable the version 2 model for the MSA validate.</param>
-        public WebAccountProviderConfig(WebAccountProviderType webAccountProviderType, string clientId = null, bool useApiVersion2 = false)
+        /// <param name="msaTokenRequestProperties">Request properties for MSA.</param>
+        /// <param name="aadTokenRequestProperties">Request properties for AAD.</param>
+        public WebAccountProviderConfig(
+            WebAccountProviderType webAccountProviderType,
+            string clientId = null,
+            IDictionary<string, string> msaTokenRequestProperties = null,
+            IDictionary<string, string> aadTokenRequestProperties = null)
         {
             WebAccountProviderType = webAccountProviderType;
             ClientId = clientId;
-            UseApiVersion2 = useApiVersion2;
+            MSATokenRequestProperties = msaTokenRequestProperties;
+            AADTokenRequestProperties = aadTokenRequestProperties;
         }
     }
 }

--- a/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
+++ b/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
@@ -20,11 +20,11 @@ namespace CommunityToolkit.Authentication
         public WebAccountProviderType WebAccountProviderType { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to use Version 2 model, the default value is <c>False</c>.
+        /// Gets or sets a value indicating whether to use Version 2 model, only for MSA, the default value is <c>False</c>.
         /// </summary>
         /// <remarks>
         /// This option is configured for pre-authorization applications.
-        /// If the application is configured with pre-authorization,
+        /// If the application is configured with MSA pre-authorization,
         /// this option can be set to <c>True</c> to skip consent page.
         /// </remarks>
         public bool UseApiVersion2 { get; set; }
@@ -34,7 +34,7 @@ namespace CommunityToolkit.Authentication
         /// </summary>
         /// <param name="webAccountProviderType">The types of accounts providers that should be available to the user.</param>
         /// <param name="clientId">The registered ClientId. Required for AAD login and admin consent.</param>
-        /// <param name="useApiVersion2">Whether to enable the version 2 model for the application.</param>
+        /// <param name="useApiVersion2">Whether to enable the version 2 model for the MSA validate.</param>
         public WebAccountProviderConfig(WebAccountProviderType webAccountProviderType, string clientId = null, bool useApiVersion2 = false)
         {
             WebAccountProviderType = webAccountProviderType;

--- a/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
+++ b/CommunityToolkit.Authentication.Uwp/WebAccountProviderConfig.cs
@@ -36,18 +36,12 @@ namespace CommunityToolkit.Authentication
         /// </summary>
         /// <param name="webAccountProviderType">The types of accounts providers that should be available to the user.</param>
         /// <param name="clientId">The registered ClientId. Required for AAD login and admin consent.</param>
-        /// <param name="msaTokenRequestProperties">Request properties for MSA.</param>
-        /// <param name="aadTokenRequestProperties">Request properties for AAD.</param>
-        public WebAccountProviderConfig(
-            WebAccountProviderType webAccountProviderType,
-            string clientId = null,
-            IDictionary<string, string> msaTokenRequestProperties = null,
-            IDictionary<string, string> aadTokenRequestProperties = null)
+        public WebAccountProviderConfig(WebAccountProviderType webAccountProviderType, string clientId = null)
         {
             WebAccountProviderType = webAccountProviderType;
             ClientId = clientId;
-            MSATokenRequestProperties = msaTokenRequestProperties;
-            AADTokenRequestProperties = aadTokenRequestProperties;
+            MSATokenRequestProperties = new Dictionary<string, string>();
+            AADTokenRequestProperties = new Dictionary<string, string>();
         }
     }
 }

--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -550,6 +550,10 @@ namespace CommunityToolkit.Authentication
                 : new WebTokenRequest(provider, scopesString, clientId);
 
             webTokenRequest.Properties.Add(GraphResourcePropertyKey, GraphResourcePropertyValue);
+            if (_webAccountProviderConfig.UseApiVersion2)
+            {
+                webTokenRequest.Properties.Add("api-version", "2.0");
+            }
 
             return webTokenRequest;
         }

--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -550,9 +550,19 @@ namespace CommunityToolkit.Authentication
                 : new WebTokenRequest(provider, scopesString, clientId);
 
             webTokenRequest.Properties.Add(GraphResourcePropertyKey, GraphResourcePropertyValue);
-            if (_webAccountProviderConfig.UseApiVersion2 && provider.Authority == MicrosoftAccountAuthority)
+            if (provider.Authority == MicrosoftAccountAuthority && _webAccountProviderConfig.MSATokenRequestProperties != null)
             {
-                webTokenRequest.Properties.Add("api-version", "2.0");
+                foreach (var property in _webAccountProviderConfig.MSATokenRequestProperties)
+                {
+                    webTokenRequest.Properties.Add(property);
+                }
+            }
+            else if (provider.Authority == AadAuthority && _webAccountProviderConfig.AADTokenRequestProperties != null)
+            {
+                foreach (var property in _webAccountProviderConfig.AADTokenRequestProperties)
+                {
+                    webTokenRequest.Properties.Add(property);
+                }
             }
 
             return webTokenRequest;

--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -550,14 +550,14 @@ namespace CommunityToolkit.Authentication
                 : new WebTokenRequest(provider, scopesString, clientId);
 
             webTokenRequest.Properties.Add(GraphResourcePropertyKey, GraphResourcePropertyValue);
-            if (provider.Authority == MicrosoftAccountAuthority && _webAccountProviderConfig.MSATokenRequestProperties != null)
+            if (provider.Authority == MicrosoftAccountAuthority)
             {
                 foreach (var property in _webAccountProviderConfig.MSATokenRequestProperties)
                 {
                     webTokenRequest.Properties.Add(property);
                 }
             }
-            else if (provider.Authority == AadAuthority && _webAccountProviderConfig.AADTokenRequestProperties != null)
+            else if (provider.Authority == AadAuthority)
             {
                 foreach (var property in _webAccountProviderConfig.AADTokenRequestProperties)
                 {

--- a/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
+++ b/CommunityToolkit.Authentication.Uwp/WindowsProvider.cs
@@ -33,7 +33,7 @@ namespace CommunityToolkit.Authentication
         private const string SettingsKeyProviderId = "WindowsProvider_ProviderId";
         private const string SettingsKeyProviderAuthority = "WindowsProvider_Authority";
 
-        private static readonly SemaphoreSlim SemaphoreSlim = new (1);
+        private static readonly SemaphoreSlim SemaphoreSlim = new(1);
 
         // Default/minimal scopes for authentication, if none are provided.
         private static readonly string[] DefaultScopes = { "User.Read" };
@@ -550,7 +550,7 @@ namespace CommunityToolkit.Authentication
                 : new WebTokenRequest(provider, scopesString, clientId);
 
             webTokenRequest.Properties.Add(GraphResourcePropertyKey, GraphResourcePropertyValue);
-            if (_webAccountProviderConfig.UseApiVersion2)
+            if (_webAccountProviderConfig.UseApiVersion2 && provider.Authority == MicrosoftAccountAuthority)
             {
                 webTokenRequest.Properties.Add("api-version", "2.0");
             }


### PR DESCRIPTION
Fixes #

Support users to inject properties when building WebTokenRequest internally. In addition, sometimes the properties applicable to MSA do not support AAD, so the two are separated for injection separately.

## PR Type

What kind of change does this PR introduce?

<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
- Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Sample app changes -->
<!-- - Other... Please describe: -->

## What is the current behavior?

Users cannot intervene in the construction process of WebTokenRequest.

## What is the new behavior?

Support adding custom properties when constructing WebTokenRequest.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](https://github.com/CommunityToolkit/Graph-Controls/blob/main/README.md)
- [ ] Sample in sample app has been added / updated (for bug fixes / features)
  - [ ] Icon has been created (if new sample) following the [Thumbnail Style Guide and templates](https://github.com/CommunityToolkit/WindowsCommunityToolkit-design-assets)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Header has been added to all new source files (run _build/UpdateHeaders.bat_)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->

## Other information
